### PR TITLE
Add codespaces devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+ARG VARIANT="3.10-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+ENV PATH="/home/vscode/.local/bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,8 +26,10 @@
         8501
     ],
     // Use 'postCreateCommand' to run commands after the container is created.
-    // Install NPM dependencies.
+    // Install app dependencies.
     "postCreateCommand": "pip install -r requirements.txt",
+    // Use 'postStartCommand' to run commands after the container is started.
+    // Start the app.
     "postStartCommand": "streamlit run Chatbot.py",
     // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/python-3
+{
+    "name": "Python 3",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": "..",
+        "args": {
+            // Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+            // Append -bullseye or -buster to pin to an OS version.
+            // Use -bullseye variants on local on arm64/Apple Silicon.
+            "VARIANT": "3.10",
+        }
+    },
+    // Set *default* container specific settings.json values on container create.
+    "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+    },
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+    ],
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [
+        8501
+    ],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // Install NPM dependencies.
+    "postCreateCommand": "pip install -r requirements.txt",
+    "postStartCommand": "streamlit run Chatbot.py",
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode",
+    "features": {
+        "git": "latest",
+        "github-cli": "latest"
+    }
+}

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,3 @@
+[server]
+enableCORS = false
+enableXsrfProtection = false


### PR DESCRIPTION
Adds a codespaces devcontainer config so that users can run the app on GitHub codespaces. Once the devcontainer is created, the app dependencies are installed, and the `Chatbot.py` app is auto launched.