### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere Models - using litellm 

### DIFF
--- a/Chatbot.py
+++ b/Chatbot.py
@@ -1,9 +1,17 @@
 import openai
 import streamlit as st
+from litellm import completion
+import os
 
 with st.sidebar:
-    openai_api_key = st.text_input("OpenAI API Key", key="chatbot_api_key", type="password")
+    
+    model = st.selectbox(
+    'Model',
+    ('gpt-3.5-turbo', 'gpt-4', 'command-nightly', 'text-davinci-003', 'claude-2', 'claude-instant-v1'))
     "[Get an OpenAI API key](https://platform.openai.com/account/api-keys)"
+    os.environ["OPENAI_API_KEY"] = st.text_input("OpenAI API Key", key="chatbot_api_key", type="password")
+    os.environ['COHERE_API_KEY'] = st.text_input("Cohere API Key", key="cohere_api_key", type="password")
+    os.environ['ANTHROPIC_API_KEY'] = st.text_input("Anthropic API Key", key="anthropic_api_key", type="password")
     "[View the source code](https://github.com/streamlit/llm-examples/blob/main/Chatbot.py)"
     "[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/streamlit/llm-examples?quickstart=1)"
 
@@ -15,14 +23,13 @@ for msg in st.session_state.messages:
     st.chat_message(msg["role"]).write(msg["content"])
 
 if prompt := st.chat_input():
-    if not openai_api_key:
+    if not os.environ["OPENAI_API_KEY"]:
         st.info("Please add your OpenAI API key to continue.")
         st.stop()
 
-    openai.api_key = openai_api_key
     st.session_state.messages.append({"role": "user", "content": prompt})
     st.chat_message("user").write(prompt)
-    response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=st.session_state.messages)
+    response = completion(model=model, messages=st.session_state.messages)
     msg = response.choices[0].message
     st.session_state.messages.append(msg)
     st.chat_message("assistant").write(msg.content)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/streamlit/llm-examples?quickstart=1)
 
+[![litellm](https://img.shields.io/badge/%20%F0%9F%9A%85%20liteLLM-chatGPT%7CAzure%7CAnthropic-blue?color=green)](https://github.com/BerriAI/litellm)
+
+
 Starter examples for building LLM apps with Streamlit.
 
 ## Overview of the App

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ openai
 duckduckgo-search
 anthropic>=0.3.0
 trubrics>=1.4.3
-litellm
+litellm==0.1.213

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ openai
 duckduckgo-search
 anthropic>=0.3.0
 trubrics>=1.4.3
+litellm


### PR DESCRIPTION
I'm the maintainer of litellm https://github.com/BerriAI/litellm - a simple & light package to call OpenAI, Azure, Cohere, Anthropic API Endpoints. 

This PR allows users to use models from the above providers in Chatbot.py
Attached ss of this working 

<img width="1253" alt="Screenshot 2023-08-02 at 1 13 15 PM" src="https://github.com/streamlit/llm-examples/assets/29436595/90268511-10e3-4bd2-a445-a1abd4a4f674">

<img width="354" alt="Screenshot 2023-08-02 at 1 13 24 PM" src="https://github.com/streamlit/llm-examples/assets/29436595/68f8a56f-d9b6-4505-96d7-22e759e7836b">


