### PR TITLE
Bump to 1.26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.24.0
+streamlit>=1.26.0
 langchain>=0.0.217
 openai
 duckduckgo-search


### PR DESCRIPTION
I tested it locally on the nightly - everything looked good, chat-with-search uses st.status beautifully and I can see the toast + chat_input fix working