### PR TITLE
Add some basic app tests (Streamlit 1.28 feature)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,39 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python application
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,4 +36,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest
+        pytest -vv

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv
-secrets.toml
 __pycache__/
+.DS_Store
+secrets.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,4 +10,4 @@ repos:
       hooks:
         - id: black
           language_version: python3.11
-          args: ["--line-length", "100"]
+          args: ["--line-length", "105"]

--- a/Chatbot.py
+++ b/Chatbot.py
@@ -23,9 +23,7 @@ if prompt := st.chat_input():
     openai.api_key = openai_api_key
     st.session_state.messages.append({"role": "user", "content": prompt})
     st.chat_message("user").write(prompt)
-    response = openai.ChatCompletion.create(
-        model="gpt-3.5-turbo", messages=st.session_state.messages
-    )
+    response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=st.session_state.messages)
     msg = response.choices[0].message
     st.session_state.messages.append(msg)
     st.chat_message("assistant").write(msg.content)

--- a/Chatbot.py
+++ b/Chatbot.py
@@ -15,7 +15,7 @@ if "messages" not in st.session_state:
 for msg in st.session_state.messages:
     st.chat_message(msg["role"]).write(msg["content"])
 
-if prompt := st.chat_input(key="chat"):
+if prompt := st.chat_input():
     if not openai_api_key:
         st.info("Please add your OpenAI API key to continue.")
         st.stop()

--- a/Chatbot.py
+++ b/Chatbot.py
@@ -15,7 +15,7 @@ if "messages" not in st.session_state:
 for msg in st.session_state.messages:
     st.chat_message(msg["role"]).write(msg["content"])
 
-if prompt := st.chat_input():
+if prompt := st.chat_input(key="chat"):
     if not openai_api_key:
         st.info("Please add your OpenAI API key to continue.")
         st.stop()
@@ -23,7 +23,9 @@ if prompt := st.chat_input():
     openai.api_key = openai_api_key
     st.session_state.messages.append({"role": "user", "content": prompt})
     st.chat_message("user").write(prompt)
-    response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=st.session_state.messages)
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo", messages=st.session_state.messages
+    )
     msg = response.choices[0].message
     st.session_state.messages.append(msg)
     st.chat_message("assistant").write(msg.content)

--- a/app_test.py
+++ b/app_test.py
@@ -17,19 +17,19 @@ def create_openai_object_sync(response: str, role: str = "assistant") -> OpenAIO
 
 @patch("openai.ChatCompletion.create")
 def test_Chatbot(openai_create):
-    at = AppTest.from_file("Chatbot.py")
-    # Todo: Remove the key in app and fix this once we have chat_input support
-    at.session_state["chat"] = "Do you know any jokes?"
-    at.run()
-    assert at.get("alert")[0].proto.body == "Please add your OpenAI API key to continue."
+    at = AppTest.from_file("Chatbot.py").run()
     assert not at.exception
+    at.chat_input[0].set_value("Do you know any jokes?").run()
+    assert at.get("alert")[0].proto.body == "Please add your OpenAI API key to continue."
 
     JOKE = "Why did the chicken cross the road? To get to the other side."
     openai_create.return_value = create_openai_object_sync(JOKE)
-    at.text_input(key="chatbot_api_key").set_value("sk-...").run()
-    print(at)
-    assert at.get("chat_message")[1].markdown[0].value == "Do you know any jokes?"
-    assert at.get("chat_message")[2].markdown[0].value == JOKE
+    at.text_input(key="chatbot_api_key").set_value("sk-...")
+    at.chat_input[0].set_value("Do you know any jokes?").run()
+    # print(at)
+    assert at.chat_message[1].markdown[0].value == "Do you know any jokes?"
+    assert at.chat_message[2].markdown[0].value == JOKE
+    assert at.chat_message[2].avatar == "assistant"
     assert not at.exception
 
 

--- a/app_test.py
+++ b/app_test.py
@@ -16,7 +16,7 @@ def create_openai_object_sync(response: str, role: str = "assistant") -> OpenAIO
 
 
 @patch("openai.ChatCompletion.create")
-def test_basic_chat(openai_create):
+def test_Chatbot(openai_create):
     at = AppTest.from_file("Chatbot.py")
     # Todo: Remove the key in app and fix this once we have chat_input support
     at.session_state["chat"] = "Do you know any jokes?"
@@ -31,3 +31,16 @@ def test_basic_chat(openai_create):
     assert at.get("chat_message")[1].markdown[0].value == "Do you know any jokes?"
     assert at.get("chat_message")[2].markdown[0].value == JOKE
     assert not at.exception
+
+
+@patch("langchain.llms.OpenAI.__call__")
+def test_Langchain_Quickstart(langchain_llm):
+    at = AppTest.from_file("pages/3_Langchain_Quickstart.py").run()
+    assert at.get("alert")[0].proto.body == "Please add your OpenAI API key to continue."
+
+    RESPONSE = "1. The best way to learn how to code is by practicing..."
+    langchain_llm.return_value = RESPONSE
+    at.sidebar.text_input[0].set_value("sk-...")
+    at.button[0].set_value(True).run()
+    print(at)
+    assert at.get("alert")[0].proto.body == RESPONSE

--- a/app_test.py
+++ b/app_test.py
@@ -20,7 +20,7 @@ def test_Chatbot(openai_create):
     at = AppTest.from_file("Chatbot.py").run()
     assert not at.exception
     at.chat_input[0].set_value("Do you know any jokes?").run()
-    assert at.get("alert")[0].proto.body == "Please add your OpenAI API key to continue."
+    assert at.info[0].value == "Please add your OpenAI API key to continue."
 
     JOKE = "Why did the chicken cross the road? To get to the other side."
     openai_create.return_value = create_openai_object_sync(JOKE)
@@ -36,11 +36,11 @@ def test_Chatbot(openai_create):
 @patch("langchain.llms.OpenAI.__call__")
 def test_Langchain_Quickstart(langchain_llm):
     at = AppTest.from_file("pages/3_Langchain_Quickstart.py").run()
-    assert at.get("alert")[0].proto.body == "Please add your OpenAI API key to continue."
+    assert at.info[0].value == "Please add your OpenAI API key to continue."
 
     RESPONSE = "1. The best way to learn how to code is by practicing..."
     langchain_llm.return_value = RESPONSE
     at.sidebar.text_input[0].set_value("sk-...")
     at.button[0].set_value(True).run()
     print(at)
-    assert at.get("alert")[0].proto.body == RESPONSE
+    assert at.info[0].value == RESPONSE

--- a/app_test.py
+++ b/app_test.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+from streamlit.testing.v1 import AppTest
+from openai.openai_object import OpenAIObject
+
+
+# See https://github.com/openai/openai-python/issues/398
+def create_openai_object_sync(response: str, role: str = "assistant") -> OpenAIObject:
+    obj = OpenAIObject()
+    message = OpenAIObject()
+    content = OpenAIObject()
+    content.content = response
+    content.role = role
+    message.message = content
+    obj.choices = [message]
+    return obj
+
+
+@patch("openai.ChatCompletion.create")
+def test_basic_chat(openai_create):
+    at = AppTest.from_file("Chatbot.py")
+    # Todo: Remove the key in app and fix this once we have chat_input support
+    at.session_state["chat"] = "Do you know any jokes?"
+    at.run()
+    assert at.get("alert")[0].proto.body == "Please add your OpenAI API key to continue."
+    assert not at.exception
+
+    JOKE = "Why did the chicken cross the road? To get to the other side."
+    openai_create.return_value = create_openai_object_sync(JOKE)
+    at.text_input(key="chatbot_api_key").set_value("sk-...").run()
+    print(at)
+    assert at.get("chat_message")[1].markdown[0].value == "Do you know any jokes?"
+    assert at.get("chat_message")[2].markdown[0].value == JOKE
+    assert not at.exception

--- a/app_test.py
+++ b/app_test.py
@@ -26,11 +26,11 @@ def test_Chatbot(openai_create):
     openai_create.return_value = create_openai_object_sync(JOKE)
     at.text_input(key="chatbot_api_key").set_value("sk-...")
     at.chat_input[0].set_value("Do you know any jokes?").run()
-    # print(at)
+    print(at)
     assert at.chat_message[1].markdown[0].value == "Do you know any jokes?"
     assert at.chat_message[2].markdown[0].value == JOKE
     assert at.chat_message[2].avatar == "assistant"
-    assert not at.exception
+    assert at.exception
 
 
 @patch("langchain.llms.OpenAI.__call__")

--- a/app_test.py
+++ b/app_test.py
@@ -30,7 +30,7 @@ def test_Chatbot(openai_create):
     assert at.chat_message[1].markdown[0].value == "Do you know any jokes?"
     assert at.chat_message[2].markdown[0].value == JOKE
     assert at.chat_message[2].avatar == "assistant"
-    assert at.exception
+    assert not at.exception
 
 
 @patch("langchain.llms.OpenAI.__call__")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ black==23.3.0
 mypy==1.4.1
 pre-commit==3.3.3
 watchdog
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit-nightly >= 1.26.1.dev20231011
+streamlit-nightly >= 1.27.3.dev20231017
 langchain>=0.0.217
 openai
 duckduckgo-search

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit-nightly >= 1.27.3.dev20231019
+streamlit>=1.28
 langchain>=0.0.217
 openai
 duckduckgo-search

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit-nightly >= 1.26.1.dev20231006
+streamlit-nightly >= 1.26.1.dev20231011
 langchain>=0.0.217
 openai
 duckduckgo-search

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.26.0
+streamlit-nightly >= 1.26.1.dev20231006
 langchain>=0.0.217
 openai
 duckduckgo-search

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit-nightly >= 1.27.3.dev20231017
+streamlit-nightly >= 1.27.3.dev20231019
 langchain>=0.0.217
 openai
 duckduckgo-search


### PR DESCRIPTION
Add some basic app tests for Chatbot and Langchain Quickstart to demonstrate the [App testing framework](https://docs.google.com/document/d/1Qscb-Ux8hEPo9hdoIjEw666wmzXO_u0JmpYo-4X6kSw/preview).

Released in 1.28. You can see the successful actions running here:
https://github.com/sfc-gh-jcarroll/llm-examples/actions