### PR TITLE
Update action steps to latest version for node16 deprecation

### DIFF
--- a/.github/workflows/app-testing.yml
+++ b/.github/workflows/app-testing.yml
@@ -13,8 +13,8 @@ jobs:
   streamlit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - uses: streamlit/streamlit-app-action@v0.0.3
@@ -23,7 +23,7 @@ jobs:
           ruff: true
           pytest-args: -v --junit-xml=test-results.xml
       - if: always()
-        uses: pmeier/pytest-results-action@main
+        uses: pmeier/pytest-results-action@v0.6.0
         with:
           path: test-results.xml
           summary: true


### PR DESCRIPTION
See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/