### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ duckduckgo-search
 anthropic>=0.3.0
 trubrics>=1.4.3
 streamlit-feedback
+langchain-community


### PR DESCRIPTION
All 3 LangChain demo pages are down as they are lacking a prerequisite library `langchain-community`, which is now added to the requirements.txt