### PR TITLE
Add sidebar links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,26 @@ OPENAI_API_KEY='xxxxxxxxxx'
 
 ## Run it locally
 
+1. Open a terminal and navigate to your project folder.
+2. Copy the following code in your terminal
+### For Windows Powershell
+
+```sh
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+streamlit run Chatbot.py
+```
+### For Windows Command
+
+```sh
+python -m venv .venv
+.venv\Scripts\activate.bat
+pip install -r requirements.txt
+streamlit run Chatbot.py
+```
+### For MacOS/Linux
+
 ```sh
 virtualenv .venv
 source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ python -m venv .venv
 pip install -r requirements.txt
 streamlit run Chatbot.py
 ```
-### For Windows Command
+### For Windows Command Prompt
 
 ```sh
 python -m venv .venv
@@ -63,7 +63,7 @@ streamlit run Chatbot.py
 ### For MacOS/Linux
 
 ```sh
-virtualenv .venv
+python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 streamlit run Chatbot.py

--- a/pages/3_Langchain_Quickstart.py
+++ b/pages/3_Langchain_Quickstart.py
@@ -6,7 +6,7 @@ st.title("🦜🔗 Langchain Quickstart App")
 with st.sidebar:
     openai_api_key = st.text_input("OpenAI API Key", type="password")
     "[Get an OpenAI API key](https://platform.openai.com/account/api-keys)"
-    "[View the source code](https://github.com/streamlit/llm-examples/blob/main/pages/4_Langchain_Quickstart.py)"
+    "[View the source code](https://github.com/streamlit/llm-examples/blob/main/pages/3_Langchain_Quickstart.py)"
     "[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/streamlit/llm-examples?quickstart=1)"
 
 

--- a/pages/3_Langchain_Quickstart.py
+++ b/pages/3_Langchain_Quickstart.py
@@ -6,6 +6,8 @@ st.title("🦜🔗 Langchain Quickstart App")
 with st.sidebar:
     openai_api_key = st.text_input("OpenAI API Key", type="password")
     "[Get an OpenAI API key](https://platform.openai.com/account/api-keys)"
+    "[View the source code](https://github.com/streamlit/llm-examples/blob/main/pages/4_Langchain_Quickstart.py)"
+    "[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/streamlit/llm-examples?quickstart=1)"
 
 
 def generate_response(input_text):

--- a/pages/4_Langchain_PromptTemplate.py
+++ b/pages/4_Langchain_PromptTemplate.py
@@ -4,6 +4,12 @@ from langchain.prompts import PromptTemplate
 
 st.title("🦜🔗 Langchain - Blog Outline Generator App")
 
+with st.sidebar:
+    openai_api_key = st.text_input("OpenAI API Key", key="feedback_api_key", type="password")
+    "[Get an OpenAI API key](https://platform.openai.com/account/api-keys)"
+    "[View the source code](https://github.com/streamlit/llm-examples/blob/main/pages/4_Langchain_PromptTemplate.py)"
+    "[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/streamlit/llm-examples?quickstart=1)"
+
 openai_api_key = st.sidebar.text_input("OpenAI API Key", type="password")
 
 

--- a/pages/4_Langchain_PromptTemplate.py
+++ b/pages/4_Langchain_PromptTemplate.py
@@ -10,7 +10,6 @@ with st.sidebar:
     "[View the source code](https://github.com/streamlit/llm-examples/blob/main/pages/4_Langchain_PromptTemplate.py)"
     "[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/streamlit/llm-examples?quickstart=1)"
 
-openai_api_key = st.sidebar.text_input("OpenAI API Key", type="password")
 
 
 def blog_outline(topic):


### PR DESCRIPTION
I added sidebar links(to the source code and a github codespaces link)  for the langchain Quickstart and langchain PromptTemplate Pages.

I have also updated the readme, to be more in line with the steps in streamlit documentation(https://docs.streamlit.io/get-started/installation/command-line). I have added parts for windows powershell , windows command prompt and MacOS/Linux